### PR TITLE
Combine the data arrays with '' instead of ','

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function attachLoggersToRequest(protocol, options, callback) {
   });
 
   req.on('response', function (res) {
-    logInfo.request.body = requestData.toString();
+    logInfo.request.body = requestData.join('');
     _.assign(logInfo.response, _.pick(res, 'statusCode', 'headers', 'trailers', 'httpVersion', 'url', 'method'));
 
     var responseData = [];
@@ -83,7 +83,7 @@ function attachLoggersToRequest(protocol, options, callback) {
       logBodyChunk(responseData, data);
     });
     res.on('end', function () {
-      logInfo.response.body = responseData.toString();
+      logInfo.response.body = responseData.join('');
       globalLogSingleton.emit('success', logInfo.request, logInfo.response);
     });
     res.on('error', function (error) {

--- a/test/global-request-logger.spec.js
+++ b/test/global-request-logger.spec.js
@@ -6,6 +6,7 @@ var
   http          = require('http'),
   https         = require('https'),
   events        = require('events'),
+  stream        = require('stream'),
   _             = require('lodash'),
   globalLogger  = require('../index')
   ;
@@ -148,6 +149,24 @@ describe('Global Request Logger', function () {
         req.write('Write to the body');
         globalLogger.once('success', function (req, res) {
           res.should.have.property('body', 'Ex');
+          done();
+        });
+      });
+
+      it('should combine chunked request body data', function (done) {
+        nock('http://www.example.com')
+          .get('/')
+          .reply(200, 'Example');
+
+        globalLogger.maxBodyLength = Infinity;
+        var req = http.get('http://www.example.com');
+        req.write('Write');
+        req.write('To');
+        req.write('The');
+        req.write('Body');
+
+        globalLogger.once('success', function (req, res) {
+          req.should.have.property('body', 'WriteToTheBody');
           done();
         });
       });


### PR DESCRIPTION
When request or response data arrives in chunks, that data is incorrectly logged due to the use of `.toString()` to combine an array of strings. The fix is to use `.join('')` instead:

```js
var arr = ['a', 'b', 'c'];
arr.toString(); // 'a,b,c'
arr.join(''); // 'abc'
```