### PR TITLE
Fix logger displaying twice the same request

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ GlobalLog.prototype.initialize = function (options) {
   try {
     saveGlobals();
     http.request = attachLoggersToRequest.bind(http, 'http');
-    https.request = attachLoggersToRequest.bind(https, 'https');
+    //https.request = attachLoggersToRequest.bind(https, 'https');
     globalLogSingleton.isEnabled = true;
   } catch (e) {
     resetGlobals();

--- a/test/global-request-logger.spec.js
+++ b/test/global-request-logger.spec.js
@@ -23,7 +23,7 @@ describe('Global Request Logger', function () {
       var origHttpsRequest = https.request;
       globalLogger.initialize();
       (http.request !== origHttpRequest).should.equal(true, 'after init http is overwritten');
-      (https.request !== origHttpsRequest).should.equal(true, 'after init https is overwritten');
+      //(https.request !== origHttpsRequest).should.equal(true, 'after init https is overwritten');
       globalLogger.end();
     });
 
@@ -33,7 +33,7 @@ describe('Global Request Logger', function () {
       globalLogger.initialize();
       globalLogger.end();
       (http.request === origHttpRequest).should.equal(true, 'after end http is restored');
-      (https.request === origHttpsRequest).should.equal(true, 'after end https is restored');
+      //(https.request === origHttpsRequest).should.equal(true, 'after end https is restored');
     });
   });
 


### PR DESCRIPTION
Following the issue https://github.com/meetearnest/global-request-logger/issues/1
I removed the bind to the https.request and indeed it's still work to log https request.
Regarding @laurence-myers 's comment, it seems that the https module is indeed just delegating to the http module after adding the security layer.