### PR TITLE
Upgrade lodash to ^4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "~2.4.1"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "@earnest/eslint-config": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,13 +757,9 @@ lodash@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
 
-lodash@^4.0.0, lodash@^4.3.0:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@~2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.3.0:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 longest@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This fixes npm audit errors caused prototype pollution in older versions of Lodash.

Fixes https://github.com/meetearnest/global-request-logger/issues/14